### PR TITLE
ブログ移行のプログラムの作成

### DIFF
--- a/bizlog.rb
+++ b/bizlog.rb
@@ -18,7 +18,7 @@ blogs.each do |blog|
 	body = blog.xpath("description").text
 	comment_list = []
 	if blog.xpath("comments").text != "" then #コメントがある場合
-		comments = blog.xpath("//comments/comment")
+		comments = blog.xpath("comments//comment")
 		comments.each do |comment_ele|
 			comment = {} 
 			comment["author"] = comment_ele.xpath("name").text
@@ -33,7 +33,7 @@ blogs.each do |blog|
 	end
 	trackback_list = []
 	if blog.xpath("trackbacks").text != "" then #トラックバックがある場合
-		trackbacks = blog.xpath("//trackbacks/trackback")
+		trackbacks = blog.xpath("trackbacks//trackback")
 		trackbacks.each do |trackback_ele|
 			trackback = {}
 			trackback["title"] = trackback_ele.xpath("title").text

--- a/bizlog.rb
+++ b/bizlog.rb
@@ -2,7 +2,7 @@ require 'nokogiri'
 require 'date'
 require 'time'
 
-	file = File.open("bizlog.xml")
+	file = File.open("0331.xml")
 	blog_doc = Nokogiri::XML(file)
 	date_format = '%m/%d/%Y %H:%M:%S'
 	blogs = blog_doc.xpath("//entry")
@@ -11,26 +11,24 @@ require 'time'
 	author = blog.xpath("author").text
 	title = blog.xpath("title").text
 	primary_category = blog.xpath("category").text
-	date = blog.xpath("date").text
+	date = blog.xpath("date").to_s
 	change_date = DateTime.parse(date)
 	date_time = change_date.strftime(date_format)
 	body = blog.xpath("description").text
-	if blog.xpath("comment") then
-		comments = blog.xpath("comments")
-		comment_list = []
+	comment_list = []
+	if blog.xpath("comments").text != "" then
+		comments = blog.xpath("comments/comment")
 			comments.each do |comment_ele|
 			comment = {} 
 			comment["author"] = comment_ele.xpath("name").text
 			comment["email"] = comment_ele.xpath("email").text
 			comment["url"] = comment_ele.xpath("url").text
 			comment["body"] = comment_ele.xpath("description").text
-			comment_date = comment_ele.xpath("date").text
-			if !comment_date.empty? then
-				comment_change_date = DateTime.parse(comment_date)
-				comment["date"] = comment_change_date.strftime(date_format).to_s
-			end
+			comment_date = comment_ele.xpath("date").to_s
+			comment_change_date = DateTime.parse(comment_date)
+			comment["date"] = comment_change_date.strftime(date_format).to_s
 			comment_list.push(comment)
-		end
+			end
 	end
 	
 #	if blog.xpath("trackback") then

--- a/bizlog.rb
+++ b/bizlog.rb
@@ -2,23 +2,24 @@ require 'nokogiri'
 require 'date'
 require 'time'
 
-	file = File.open("0331.xml")
-	blog_doc = Nokogiri::XML(file)
-	date_format = '%m/%d/%Y %H:%M:%S'
-	blogs = blog_doc.xpath("//entry")
+#XMLからMovable Typeに変換するプログラム
+file = File.open("bizlog.xml")
+blog_doc = Nokogiri::XML(file)
+date_format = '%m/%d/%Y %H:%M:%S'
+blogs = blog_doc.xpath("//entry")
 
-	blogs.each do |blog|
+blogs.each do |blog|
 	author = blog.xpath("author").text
 	title = blog.xpath("title").text
 	primary_category = blog.xpath("category").text
 	date = blog.xpath("date").to_s
 	change_date = DateTime.parse(date)
-	date_time = change_date.strftime(date_format)
+	date_time = change_date.strftime(date_format) #dateの形式を合わせる
 	body = blog.xpath("description").text
 	comment_list = []
-	if blog.xpath("comments").text != "" then
-		comments = blog.xpath("comments/comment")
-			comments.each do |comment_ele|
+	if blog.xpath("comments").text != "" then #コメントがある場合
+		comments = blog.xpath("//comments/comment")
+		comments.each do |comment_ele|
 			comment = {} 
 			comment["author"] = comment_ele.xpath("name").text
 			comment["email"] = comment_ele.xpath("email").text
@@ -28,21 +29,26 @@ require 'time'
 			comment_change_date = DateTime.parse(comment_date)
 			comment["date"] = comment_change_date.strftime(date_format).to_s
 			comment_list.push(comment)
-			end
+		end
 	end
-	
-#	if blog.xpath("trackback") then
-#		trackbacks = blog.xpath("trackbacks")
+	trackback_list = []
+	if blog.xpath("trackbacks").text != "" then #トラックバックがある場合
+		trackbacks = blog.xpath("//trackbacks/trackback")
+		trackbacks.each do |trackback_ele|
+			trackback = {}
+			trackback["title"] = trackback_ele.xpath("title").text
+			trackback["url"] = trackback_ele.xpath("url").text
+			trackback["ip"] = trackback_ele.xpath("ip").text
+			trackback["blog_name"] = trackback_ele.xpath("blog_name").text
+			trackback_date = trackback_ele.xpath("date").to_s
+			trackback_change_date = DateTime.parse(trackback_date)
+			trackback["date"] = trackback_change_date.strftime(date_format).to_s
+			trackback["excerpt"] = trackback_ele.xpath("excerpt").text
+			trackback_list.push(trackback)
+		end
+	end 
 
-#		trackbacks.each do |trackback|
-#			trackback_title = trackback.xpath("title")
-#			trackback_url = trackback.xpath("url")
-#			trackback_date = trackback.xpath("date")
-#			trackback_change_date = DateTime.parse(trackback_date)
-#			trackback_date_time = track_change_date.strftime(date_format)
-#		end
-#	end 
-
+#Movable Typeに変換したものを書き出す
 	puts "AUTHOR:" + author 
 	puts "TITLE:" + title
 	puts "STATUS:Publish"
@@ -56,18 +62,23 @@ require 'time'
 	puts "KEYWORDS:" + "\n-----"
 	if !comment_list.empty? then
 		comment_list.each do |comment|
-		puts "COMMENT:"
-		puts "AUTHOR:" + comment["author"]
-		puts "DATE:" + comment["date"].to_s
-		puts "EMAIL:" + comment["email"]
-		puts comment["body"] + "\n-----"
+			puts "COMMENT:"
+			puts "AUTHOR:" + comment["author"]
+			puts "DATE:" + comment["date"].to_s
+			puts "EMAIL:" + comment["email"]
+			puts comment["body"] + "\n-----"
 		end
 	end
-#	puts "PING:"
-#	puts "TITLE:"
-#	puts "URL:"
-#	puts "IP:"
-#	puts "BLOG NAME:"
-#	puts "DATE:"	
-	puts "--------"
+	if !trackback_list.empty? then
+		trackback_list.each do |trackback|
+			puts "PING:"
+			puts "TITLE:" + trackback["title"]
+			puts "URL:" + trackback["url"]
+			puts "IP:" + trackback["ip"]
+			puts "BLOG NAME:" + trackback["blog_name"]
+			puts "DATE:" + trackback["date"]
+			puts trackback["excerpt"] + "\n-----"	
+		end	
 	end
+	puts "--------"
+end


### PR DESCRIPTION
メニュー内容
現行の会社の技術ブログを刷新したい。そのため、現在の記事をエクスポートして、markdown形式に変換したい。できれば画像のダウンロードも。必要であればPythonなどで変換スクリプトを書く必要がありそう。

やること
- [x] 記事のインポート
- [x] コメントのインポート
- [x] トラックバックのインポート
- [ ] 画像のインポート

画像はインポートすることができないので、画像共有サイトなどに一度アップロードしてから記事内のリンクを修正する必要がありそう。

記事のインポートにつかったはてなブログ
http://kikuchik.hatenablog.com/